### PR TITLE
fix: 修正 remoting 示例中的 group 命名和地址格式

### DIFF
--- a/v5/python/remoting/broadcast/BroadcastConsumer1.py
+++ b/v5/python/remoting/broadcast/BroadcastConsumer1.py
@@ -15,9 +15,9 @@ def callback(msg):
 
 
 # 初始化消费者，并设置消费者组信息
-consumer = PushConsumer('rocketmq-xxx|namespace_python%group11')
+consumer = PushConsumer('ConsumerGroup')
 # 设置服务地址
-consumer.set_name_server_address('rocketmq-xxx.rocketmq.ap-bj.public.tencenttdmq.com:9876')
+consumer.set_name_server_address('rmq-xxxx.rocketmq.gz.qcloud.tencenttdmq.com:8080')
 # 设置权限（角色名和密钥）
 consumer.set_session_credentials(
     'eyJrZXlJZC......',
@@ -27,7 +27,7 @@ consumer.set_session_credentials(
 # 设置为集群消息模式
 consumer.set_message_model(MessageModel.BROADCASTING)
 # 订阅topic
-consumer.subscribe('rocketmq-xxx|namespace_python%topic1', callback)
+consumer.subscribe('topic1', callback)
 print(' [Consumer] Waiting for messages.')
 # 启动消费者
 consumer.start()

--- a/v5/python/remoting/broadcast/BroadcastConsumer2.py
+++ b/v5/python/remoting/broadcast/BroadcastConsumer2.py
@@ -19,9 +19,9 @@ def callback(msg):
 
 
 # 初始化消费者，并设置消费者组信息
-consumer = PushConsumer('rocketmq-xxx|namespace_python%group11')
+consumer = PushConsumer('ConsumerGroup')
 # 设置服务地址
-consumer.set_name_server_address('rocketmq-xxx.rocketmq.ap-bj.public.tencenttdmq.com:9876')
+consumer.set_name_server_address('rmq-xxxx.rocketmq.gz.qcloud.tencenttdmq.com:8080')
 # 设置权限（角色名和密钥）
 consumer.set_session_credentials(
     'eyJrZXlJZC......',
@@ -31,7 +31,7 @@ consumer.set_session_credentials(
 # 设置为集群消息模式
 consumer.set_message_model(MessageModel.BROADCASTING)
 # 订阅topic
-consumer.subscribe('rocketmq-xxx|namespace_python%topic1', callback)
+consumer.subscribe('topic1', callback)
 print(' [Consumer] Waiting for messages.')
 # 启动消费者
 consumer.start()

--- a/v5/python/remoting/broadcast/SimpleProducer.py
+++ b/v5/python/remoting/broadcast/SimpleProducer.py
@@ -1,9 +1,9 @@
 from rocketmq.client import Producer, Message
 
 # 初始化生产者，并设置生产组信息
-producer = Producer('group1')
+producer = Producer('ProducerGroup')
 # 设置服务地址
-producer.set_name_server_address('rocketmq-xxx.rocketmq.ap-bj.public.tencenttdmq.com:9876')
+producer.set_name_server_address('rmq-xxxx.rocketmq.gz.qcloud.tencenttdmq.com:8080')
 # 设置权限（角色名和密钥）
 producer.set_session_credentials(
     'eyJrZXlJZC......',
@@ -15,7 +15,7 @@ producer.start()
 
 for i in range(10):
     # 组装消息
-    msg = Message('rocketmq-xxx|namespace_python%topic1')
+    msg = Message('topic1')
     # 消息内容
     msg.set_body('This is a new message' + str(i) + '.')
 

--- a/v5/python/remoting/delay/SendDelayMessage.py
+++ b/v5/python/remoting/delay/SendDelayMessage.py
@@ -3,9 +3,9 @@ import time
 from rocketmq.client import Producer, Message
 
 # 初始化生产者，并设置生产组信息
-producer = Producer('group1')
+producer = Producer('ProducerGroup')
 # 设置服务地址
-producer.set_name_server_address('rocketmq-xxx.rocketmq.ap-bj.public.tencenttdmq.com:9876')
+producer.set_name_server_address('rmq-xxxx.rocketmq.gz.qcloud.tencenttdmq.com:8080')
 # 设置权限（角色名和密钥）
 producer.set_session_credentials(
     'eyJrZXlJZC......',
@@ -16,7 +16,7 @@ producer.set_session_credentials(
 producer.start()
 
 # 组装消息
-msg = Message('rocketmq-xxx|namespace_python%topic1')
+msg = Message('topic1')
 # 设置keys
 msg.set_keys('yourKey')
 # 设置tags

--- a/v5/python/remoting/delay/SendTimerMessage.py
+++ b/v5/python/remoting/delay/SendTimerMessage.py
@@ -3,9 +3,9 @@ import time
 from rocketmq.client import Producer, Message
 
 # 初始化生产者，并设置生产组信息
-producer = Producer('group1')
+producer = Producer('ProducerGroup')
 # 设置服务地址
-producer.set_name_server_address('rocketmq-xxx.rocketmq.ap-bj.public.tencenttdmq.com:9876')
+producer.set_name_server_address('rmq-xxxx.rocketmq.gz.qcloud.tencenttdmq.com:8080')
 # 设置权限（角色名和密钥）
 producer.set_session_credentials(
     'eyJrZXlJZC......',
@@ -16,7 +16,7 @@ producer.set_session_credentials(
 producer.start()
 
 # 组装消息
-msg = Message('rocketmq-xxx|namespace_python%topic1')
+msg = Message('topic1')
 # 设置keys
 msg.set_keys('yourKey')
 # 设置tags

--- a/v5/python/remoting/order/OrderConsumer.py
+++ b/v5/python/remoting/order/OrderConsumer.py
@@ -18,9 +18,9 @@ def callback(msg):
 
 
 # 初始化消费者，并设置消费者组信息
-consumer = PushConsumer('rocketmq-xxx|namespace_python%group22')
+consumer = PushConsumer('OrderConsumerGroup')
 # 设置服务地址
-consumer.set_name_server_address('rocketmq-xxx.rocketmq.ap-bj.public.tencenttdmq.com:9876')
+consumer.set_name_server_address('rmq-xxxx.rocketmq.gz.qcloud.tencenttdmq.com:8080')
 # 设置权限（角色名和密钥）
 consumer.set_session_credentials(
     'eyJrZXlJZC......',
@@ -28,7 +28,7 @@ consumer.set_session_credentials(
     ''
 )
 # 订阅topic
-consumer.subscribe('rocketmq-xxx|namespace_python%topic2', callback)
+consumer.subscribe('topic2', callback)
 print(' [Consumer] Waiting for messages.')
 # 启动消费者
 consumer.start()

--- a/v5/python/remoting/order/OrderProducer.py
+++ b/v5/python/remoting/order/OrderProducer.py
@@ -5,9 +5,9 @@ from rocketmq.client import Producer, Message
 """
 
 # 初始化生产者，并设置生产组信息
-producer = Producer('group2')
+producer = Producer('OrderProducerGroup')
 # 设置服务地址
-producer.set_name_server_address('rocketmq-xxx.rocketmq.ap-bj.public.tencenttdmq.com:9876')
+producer.set_name_server_address('rmq-xxxx.rocketmq.gz.qcloud.tencenttdmq.com:8080')
 # 设置权限（角色名和密钥）
 producer.set_session_credentials(
     'eyJrZXlJZC......',
@@ -19,7 +19,7 @@ producer.start()
 
 for i in range(10):
     # 组装消息
-    msg = Message('rocketmq-xxx|namespace_python%topic2')
+    msg = Message('topic2')
     # 消息内容
     msg.set_body('This is a new message' + str(i) + '.')
 

--- a/v5/python/remoting/simple/OnewaySendMessage.py
+++ b/v5/python/remoting/simple/OnewaySendMessage.py
@@ -1,9 +1,9 @@
 from rocketmq.client import Producer, Message
 
 # 初始化生产者，并设置生产组信息
-producer = Producer('group1')
+producer = Producer('ProducerGroup')
 # 设置服务地址
-producer.set_name_server_address('rocketmq-xxx.rocketmq.ap-bj.public.tencenttdmq.com:9876')
+producer.set_name_server_address('rmq-xxxx.rocketmq.gz.qcloud.tencenttdmq.com:8080')
 # 设置权限（角色名和密钥）
 producer.set_session_credentials(
     'eyJrZXlJZC......',
@@ -14,7 +14,7 @@ producer.set_session_credentials(
 producer.start()
 
 # 组装消息
-msg = Message('rocketmq-xxx|namespace_python%topic1')
+msg = Message('topic1')
 # 设置keys
 msg.set_keys('yourKey')
 # 设置tags

--- a/v5/python/remoting/simple/SimplePushConsumer.py
+++ b/v5/python/remoting/simple/SimplePushConsumer.py
@@ -14,9 +14,9 @@ def callback(msg):
 
 
 # 初始化消费者，并设置消费者组信息
-consumer = PushConsumer('rocketmq-xxx|namespace_python%group11')
+consumer = PushConsumer('ConsumerGroup')
 # 设置服务地址
-consumer.set_name_server_address('rocketmq-xxx.rocketmq.ap-bj.public.tencenttdmq.com:9876')
+consumer.set_name_server_address('rmq-xxxx.rocketmq.gz.qcloud.tencenttdmq.com:8080')
 # 设置权限（角色名和密钥）
 consumer.set_session_credentials(
     'eyJrZXlJZC......',
@@ -24,7 +24,7 @@ consumer.set_session_credentials(
     ''
 )
 # 订阅topic
-consumer.subscribe('rocketmq-xxx|namespace_python%topic1', callback, "*")
+consumer.subscribe('topic1', callback, "*")
 print(' [Consumer] Waiting for messages.')
 # 启动消费者
 consumer.start()

--- a/v5/python/remoting/simple/SyncSendMessage.py
+++ b/v5/python/remoting/simple/SyncSendMessage.py
@@ -1,9 +1,9 @@
 from rocketmq.client import Producer, Message
 
 # 初始化生产者，并设置生产组信息
-producer = Producer('group1')
+producer = Producer('ProducerGroup')
 # 设置服务地址
-producer.set_name_server_address('rocketmq-xxx.rocketmq.ap-bj.public.tencenttdmq.com:9876')
+producer.set_name_server_address('rmq-xxxx.rocketmq.gz.qcloud.tencenttdmq.com:8080')
 # 设置权限（角色名和密钥）
 producer.set_session_credentials(
     'eyJrZXlJZC......',
@@ -14,7 +14,7 @@ producer.set_session_credentials(
 producer.start()
 
 # 组装消息
-msg = Message('rocketmq-xxx|namespace_python%topic1')
+msg = Message('topic1')
 # 设置keys
 msg.set_keys('yourKey')
 # 设置tags


### PR DESCRIPTION
- group 命名标准化：group1→ProducerGroup, group2→OrderProducerGroup, group11→ConsumerGroup, group22→OrderConsumerGroup
- 去掉 group 中的 rocketmq-xxx|namespace_python% 租户前缀
- nameserver 地址格式统一为 rmq-xxxx.rocketmq.gz.qcloud.tencenttdmq.com:8080